### PR TITLE
[Feature] ControllerクラスのgetAirportメソッドに例外処理を追加

### DIFF
--- a/src/main/java/practice/kadai2209_7th/AirportController.java
+++ b/src/main/java/practice/kadai2209_7th/AirportController.java
@@ -1,6 +1,5 @@
 package practice.kadai2209_7th;
 
-
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -8,13 +7,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
-import practice.kadai2209_7th.exceptionhandelers.AirportNotFoundException;
 
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 import java.net.URI;
-import java.time.ZonedDateTime;
 import java.util.*;
 
 
@@ -23,44 +19,24 @@ import java.util.*;
 @RequestMapping("/airports")
 public class AirportController {
 
-
     private final String NOT_FOUND_MESSAGE = "not found";
 
     @Autowired
     private AirportService service;
 
-
     @ResponseStatus(code = HttpStatus.OK)
     @GetMapping("/airports")
     public GetAirportCodeResponse getAirportList() {
-
         return new GetAirportCodeResponse("You have airport codes listed here", service.getAllAirportCodeList());
     }
-
 
     @GetMapping("/search")
     public ResponseEntity<Map<String, AirportEntity>> getAirport(
             @RequestParam(value = "airportCode") @Size(min = 3, max = 3, message = "Number of letters has to be 3") String airportCode) {
 
         Map<String, AirportEntity> searchedAirport = Map.of("airport", service.getAirportEntity(airportCode));
-
         return ResponseEntity.ok(searchedAirport);
     }
-
-    //Exception Handling in getAirport
-    @ExceptionHandler(value = AirportNotFoundException.class)
-    public ResponseEntity<Map<String, String>> handleNoAirportFound(@NotNull AirportNotFoundException e, @NotNull HttpServletRequest request) {
-
-        Map<String, String> body = new HashMap<>();
-        body.put("timestamp", ZonedDateTime.now().toString());
-        body.put("status", String.valueOf(HttpStatus.NOT_FOUND.value()));
-        body.put("error", HttpStatus.NOT_FOUND.getReasonPhrase());
-        body.put("message", e.getMessage());
-        body.put("path", request.getRequestURI());
-
-        return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
-    }
-
 
     @PostMapping("/create")
     public ResponseEntity<Map<String, AirportEntity>> createAirport(
@@ -69,15 +45,11 @@ public class AirportController {
             @RequestParam(value = "country") @NotBlank(message = "Country is required field") String country,
             UriComponentsBuilder uriBuilder) {
 
-        //Body of ResponseEntity
         Map<String, AirportEntity> createdAirportMap = new HashMap<>();
-
         Map<String, List<String>> yourAirportMap = service.getAllDataMap();
-
         List<String> airportInfoList = yourAirportMap.getOrDefault(airportCode, List.of(NOT_FOUND_MESSAGE, NOT_FOUND_MESSAGE));
 
         if (airportInfoList.get(0).equals(NOT_FOUND_MESSAGE)) {
-
             yourAirportMap.put(airportCode, Arrays.asList(airportName, country));
             createdAirportMap.put("airport", new AirportEntity(airportCode, airportName, country));
 
@@ -87,18 +59,13 @@ public class AirportController {
                     .toUri();
 
             return ResponseEntity.created(url).body(createdAirportMap);
-
         } else {
-
             createdAirportMap.put("airport", new AirportEntity(airportCode + "  ** Already exists **",
                     airportInfoList.get(0), airportInfoList.get(1)));
 
             return ResponseEntity.status(HttpStatus.CONFLICT).body(createdAirportMap);
-
         }
-
     }
-
 
     @PatchMapping("/update/{airportCode}")
     public ResponseEntity<Map<String, AirportEntity>> updateAirport(
@@ -106,65 +73,46 @@ public class AirportController {
             @RequestParam("airportName") @NotBlank(message = "Airport Name is required field") String airportName,
             @RequestParam("country") @NotBlank(message = "Country is required field") String country) {
 
-        //Body of ResponseEntity
         Map<String, AirportEntity> updatedAirportMap = new LinkedHashMap<>();
-
         Map<String, List<String>> yourAirportMap = service.getAllDataMap();
-
         List<String> airportInfoList = yourAirportMap.getOrDefault(airportCode, List.of(NOT_FOUND_MESSAGE, NOT_FOUND_MESSAGE));
 
         if (airportInfoList.get(0).equals(NOT_FOUND_MESSAGE)) {
-
             updatedAirportMap.put("airport", new AirportEntity(airportCode, airportInfoList.get(0), airportInfoList.get(1)));
 
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(updatedAirportMap);
-
         } else if (airportInfoList.equals(List.of(airportName, country))) {
-
             updatedAirportMap.put("airport", new AirportEntity(airportCode,
                     airportInfoList.get(0) + "  ** The same Airport Name **",
                     airportInfoList.get(1) + "  ** The same Country **"));
 
             return ResponseEntity.status(HttpStatus.CONFLICT).body(updatedAirportMap);
-
         } else {
-
             yourAirportMap.put(airportCode, Arrays.asList(airportName, country));
-
             updatedAirportMap.put("before", new AirportEntity(airportCode, airportInfoList.get(0), airportInfoList.get(1)));
             updatedAirportMap.put("after", new AirportEntity(airportCode, airportName, country));
 
             return ResponseEntity.ok(updatedAirportMap);
-
         }
-
     }
-
 
     @DeleteMapping("/delete/{airportCode}")
     public ResponseEntity<Map<String, AirportEntity>> deleteAirport(
             @PathVariable("airportCode") @Size(min = 3, max = 3, message = "Number of letters has to be 3")
             String airportCode) {
 
-        //Body of ResponseEntity
         Map<String, AirportEntity> deletedAirportMap = new HashMap<>();
-
         Map<String, List<String>> yourAirportMap = service.getAllDataMap();
-
         List<String> airportInfoList = yourAirportMap.getOrDefault(airportCode, List.of(NOT_FOUND_MESSAGE, NOT_FOUND_MESSAGE));
 
         if (airportInfoList.get(0).equals(NOT_FOUND_MESSAGE)) {
-
             deletedAirportMap.put("airport", new AirportEntity(airportCode, airportInfoList.get(0), airportInfoList.get(1)));
 
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(deletedAirportMap);
-
         } else {
-
             yourAirportMap.remove(airportCode);
 
             return ResponseEntity.noContent().build();
-
         }
     }
 

--- a/src/main/java/practice/kadai2209_7th/AirportRepository.java
+++ b/src/main/java/practice/kadai2209_7th/AirportRepository.java
@@ -6,9 +6,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.rowset.SqlRowSet;
 import org.springframework.stereotype.Repository;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @Repository
 public class AirportRepository {
@@ -16,11 +14,23 @@ public class AirportRepository {
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
-    public Map<String, Object> findByCode(String airportCode) {
+    public Optional<Map<String, Object>> findByCode(String airportCode) {
 
         String query = "SELECT * FROM airports WHERE airportCode=?";
 
-        return jdbcTemplate.queryForMap(query, airportCode);
+        Map<String, Object> foundAirport;
+
+        try {
+
+            foundAirport = jdbcTemplate.queryForMap(query, airportCode);
+
+        } catch (org.springframework.dao.EmptyResultDataAccessException e) {
+
+            foundAirport = null;
+
+        }
+
+        return Optional.ofNullable(foundAirport);
     }
 
     public List<String> findAllCode() {

--- a/src/main/java/practice/kadai2209_7th/AirportService.java
+++ b/src/main/java/practice/kadai2209_7th/AirportService.java
@@ -3,6 +3,7 @@ package practice.kadai2209_7th;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import org.springframework.stereotype.Service;
+import practice.kadai2209_7th.exceptionhandelers.AirportNotFoundException;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -17,13 +18,24 @@ public class AirportService {
 
     public AirportEntity getAirportEntity(String airport_code) {
 
-        Map<String, Object> map = repository.findByCode(airport_code);
+        String airportCode;
+        String airportName;
+        String country;
 
-        String airportCode = (String) map.get("airportCode");
-        String airportName = (String) map.get("airportName");
-        String country = (String) map.get("country");
+        if (repository.findByCode(airport_code).isPresent()) {
 
-        return new AirportEntity(airportCode, airportName, country);
+            Map<String, Object> map = repository.findByCode(airport_code).get();
+            airportCode = (String) map.get("airportCode");
+            airportName = (String) map.get("airportName");
+            country = (String) map.get("country");
+
+            return new AirportEntity(airportCode, airportName, country);
+
+        } else {
+
+            throw new AirportNotFoundException(airport_code + " Not Found");
+
+        }
     }
 
     public List<String> getAllAirportCodeList() {

--- a/src/main/java/practice/kadai2209_7th/exceptionhandelers/AirportNotFoundException.java
+++ b/src/main/java/practice/kadai2209_7th/exceptionhandelers/AirportNotFoundException.java
@@ -1,0 +1,21 @@
+package practice.kadai2209_7th.exceptionhandelers;
+
+public class AirportNotFoundException extends RuntimeException {
+
+    public AirportNotFoundException() {
+        super();
+    }
+
+    public AirportNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public AirportNotFoundException(String message) {
+        super(message);
+    }
+
+    public AirportNotFoundException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/src/main/java/practice/kadai2209_7th/exceptionhandelers/AirportNotFoundExceptionHandler.java
+++ b/src/main/java/practice/kadai2209_7th/exceptionhandelers/AirportNotFoundExceptionHandler.java
@@ -1,0 +1,30 @@
+package practice.kadai2209_7th.exceptionhandelers;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import javax.servlet.http.HttpServletRequest;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class AirportNotFoundExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(value = AirportNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleNoAirportFound(@NotNull AirportNotFoundException e, @NotNull HttpServletRequest request) {
+
+        Map<String, String> body = new HashMap<>();
+        body.put("timestamp", ZonedDateTime.now().toString());
+        body.put("status", String.valueOf(HttpStatus.NOT_FOUND.value()));
+        body.put("error", HttpStatus.NOT_FOUND.getReasonPhrase());
+        body.put("message", e.getMessage());
+        body.put("path", request.getRequestURI());
+
+        return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
+    }
+}


### PR DESCRIPTION
## 概要
ControllerクラスのgetAirportメソッド（@GetMapping("/search")）において、
・レスポンス＆ステータスコードをif文を使った切り替えから箇所を例外処理へ書き換え
・getAirportメソッドのレスポンスボディに必要なのは空港コードに対応する空港のエンティティのみであることから、全空港情報をMapで取得するgetAllDataMapメソッドの使用をやめ、代わりにgetAirportEntitiyメソッドを使用。


## 実行結果
### OK（検索した空港コードが登録されている場合）の場合
![20221105_Kadai7_5_exception_search_ok](https://user-images.githubusercontent.com/113277395/200155531-d5001477-2bd3-4d6d-9b64-a0016628a613.png)

### NOT FOUND（検索した空港コードが登録されていない場合）の場合
![20221105_Kadai7_5_exception_search](https://user-images.githubusercontent.com/113277395/200155524-c2447ad2-aa9d-4f7a-88bb-01d16d7e6f31.png)
