### PR TITLE
[Fix] Serviceクラスのインターフェース/実装分離・パッケージ整理

### DIFF
--- a/src/main/java/practice/kadai22sep7th/controller/AirportCodeResponse.java
+++ b/src/main/java/practice/kadai22sep7th/controller/AirportCodeResponse.java
@@ -1,6 +1,7 @@
-package practice.kadai22sep7th;
+package practice.kadai22sep7th.controller;
 
 import lombok.Data;
+import practice.kadai22sep7th.entity.AirportEntity;
 
 import java.util.List;
 

--- a/src/main/java/practice/kadai22sep7th/controller/AirportController.java
+++ b/src/main/java/practice/kadai22sep7th/controller/AirportController.java
@@ -1,4 +1,4 @@
-package practice.kadai22sep7th;
+package practice.kadai22sep7th.controller;
 
 import lombok.AllArgsConstructor;
 //import org.jetbrains.annotations.NotNull;
@@ -6,6 +6,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import practice.kadai22sep7th.entity.AirportEntity;
+import practice.kadai22sep7th.service.AirportService;
+import practice.kadai22sep7th.service.AirportServiceImpl;
 //import org.springframework.web.util.UriComponentsBuilder;
 
 //import javax.validation.constraints.NotBlank;

--- a/src/main/java/practice/kadai22sep7th/entity/AirportEntity.java
+++ b/src/main/java/practice/kadai22sep7th/entity/AirportEntity.java
@@ -1,4 +1,4 @@
-package practice.kadai22sep7th;
+package practice.kadai22sep7th.entity;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -6,7 +6,7 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class AirportEntity {
-    
+
     private final String airportCode;
     private String airportName;
     private String country;

--- a/src/main/java/practice/kadai22sep7th/mapper/AirportMapper.java
+++ b/src/main/java/practice/kadai22sep7th/mapper/AirportMapper.java
@@ -2,7 +2,7 @@ package practice.kadai22sep7th.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
-import practice.kadai22sep7th.AirportEntity;
+import practice.kadai22sep7th.entity.AirportEntity;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/practice/kadai22sep7th/service/AirportService.java
+++ b/src/main/java/practice/kadai22sep7th/service/AirportService.java
@@ -1,0 +1,13 @@
+package practice.kadai22sep7th.service;
+
+import practice.kadai22sep7th.entity.AirportEntity;
+
+import java.util.List;
+
+public interface AirportService {
+
+    public AirportEntity getAirport(String airportCode);
+
+    public List<AirportEntity> getAllAirports();
+
+}

--- a/src/main/java/practice/kadai22sep7th/service/AirportServiceImpl.java
+++ b/src/main/java/practice/kadai22sep7th/service/AirportServiceImpl.java
@@ -1,8 +1,9 @@
-package practice.kadai22sep7th;
+package practice.kadai22sep7th.service;
 
 import lombok.AllArgsConstructor;
 
 import org.springframework.stereotype.Service;
+import practice.kadai22sep7th.entity.AirportEntity;
 import practice.kadai22sep7th.exceptionhandelers.AirportNotFoundException;
 import practice.kadai22sep7th.mapper.AirportMapper;
 
@@ -10,14 +11,16 @@ import java.util.List;
 
 @AllArgsConstructor
 @Service
-public class AirportService {
+public class AirportServiceImpl implements AirportService {
 
     private final AirportMapper airportMapper;
 
+    @Override
     public AirportEntity getAirport(String airportCode) {
         return airportMapper.findById(airportCode).orElseThrow(() -> new AirportNotFoundException(airportCode + " Not Found"));
     }
 
+    @Override
     public List<AirportEntity> getAllAirports() {
         return airportMapper.findAll();
     }


### PR DESCRIPTION
## 概要
プロジェクト全体の整理のため以下実施
・AirportServiceクラスをインターフェースと実装に分離
・クラスの役割別にパッケージを作成しグルーピング
![image](https://user-images.githubusercontent.com/113277395/204080634-5b02ddaf-8357-4ab1-a51e-948f65ae3fdc.png)
